### PR TITLE
Bump terraform version from 0.12.20 to 0.12.21

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "::set-env name=PACKER_VERSION::1.5.4"
-echo "::set-env name=TERRAFORM_VERSION::0.12.20"
+echo "::set-env name=TERRAFORM_VERSION::0.12.21"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

From: https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md

## Terraform 0.12.21 (February 19, 2020)

NEW FEATURES:
* backend/cos: New backend "cos", supporting using Tencent Cloud Storage as a remote backend.
* command/login: Enable "terraform login" and add support for UI-generated tokens ([#23995](https://github.com/hashicorp/terraform/issues/23995))
* command/logout: Add "terraform logout" command to remove local credentials ([#24048](https://github.com/hashicorp/terraform/issues/24048))

ENHANCEMENTS:

* command/workspace delete: release lock after workspace removal warning ([#24085](https://github.com/hashicorp/terraform/issues/24085))
* lang/funcs: add `setsubtract` function ([#23424](https://github.com/hashicorp/terraform/issues/23424))

BUG FIXES:
* command/state show: Fix an issue when a resource has a non-default provider configured ([#24027](https://github.com/hashicorp/terraform/issues/24027))
* backend/remote-state: Fix issues where lingering lock files remained when deleting non-empty workspaces ([#24085](https://github.com/hashicorp/terraform/issues/24085))
* command/import: Release lock if initialization error occurs on import ([#23318](https://github.com/hashicorp/terraform/issues/23318))
* terraform: Fix panic when using `for_each` with a set containing `null` values ([#24047](https://github.com/hashicorp/terraform/issues/24047))
