### PR TITLE
Bump terraform version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "::set-env name=PACKER_VERSION::1.5.4"
-echo "::set-env name=TERRAFORM_VERSION::0.12.21"
+echo "::set-env name=TERRAFORM_VERSION::0.12.23"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

## 0.12.23 (March 05, 2020)

BUG FIXES:
* cli: Fix wrong version returned by `terraform version`
 @felddy  -> 🤣 

## 0.12.22 (March 05, 2020)

ENHANCEMENTS:
* registry: Add configurable retries for module and provider discovery requests to the remote registry ([#24260](https://github.com/hashicorp/terraform/pull/24260))
* registry: Add configurable request timeout for the remote registry client ([#24259](https://github.com/hashicorp/terraform/pull/24259))

BUG FIXES:

* cli: Fix terraform state mv to correctly set the resource each mode based on the target address ([#24254](https://github.com/hashicorp/terraform/issues/24254))
* cli: The `terraform plan` command (and the implied plan run by `terraform apply` with no arguments) will now print any warnings that were generated even if there are no changes to be made. ([#24095](https://github.com/hashicorp/terraform/issues/24095))

