### PR TITLE
Bump terraform version 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "::set-env name=PACKER_VERSION::1.5.4"
-echo "::set-env name=TERRAFORM_VERSION::0.12.23"
+echo "::set-env name=TERRAFORM_VERSION::0.12.24"


### PR DESCRIPTION
# Terraform version bump 0.12.23 -> 0.12.24

## 0.12.24 (March 19, 2020)

NOTES:

* cli: Windows executable signing.

Our Windows 32-bit and 64-bit executables for this version and up will be signed with a HashiCorp cert. Windows users will no longer see a warning about an "unknown publisher" when running our software.

BUG FIXES:
* command/login: Fix bug when using terraform login on Windows ([#24397](https://github.com/hashicorp/terraform/issues/24397))
* registry: Fix panic when server is unreachable ([#24411](https://github.com/hashicorp/terraform/issues/24411))
