### PR TITLE
Upgrade to Packer 1.7.3

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "PACKER_VERSION=1.6.6" >> "$GITHUB_ENV"
+echo "PACKER_VERSION=1.7.3" >> "$GITHUB_ENV"
 echo "TERRAFORM_VERSION=0.12.31" >> "$GITHUB_ENV"


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the packer version to the current latest, which is 1.7.3.

## 💭 Motivation and context ##

cisagov/skeleton-packer#77 requires Packer 1.7+.

Resolves cisagov/skeleton-packer#70.

If this breaks any of the repositories based on [cisagov/skeleton-packer](https://github.com/cisagov.skeleton-packer) then we will simply fix them.  We mustn't allow ourselves to be left behind as the world moves on.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
