### PR TITLE
Set Action Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ None
 
 | Name              | Description |
 |-------------------|-------------|
-| PACKER_VERSION    | The version of [Packer](https://packer.io) to use. |
-| SHFMT_VERSION | The version of [shfmt](https://github.com/mvdan/sh#shfmt) to use. |
-| TERRAFORM_VERSION | The version of [Terraform](https://terraform.io) to use. |
-| TERRAFORM_DOCS_VERSION | The version of [terraform-docs](https://github.com/terraform-docs/terraform-docs) to use. |
+| packer-version | The version of [Packer](https://packer.io) to use. |
+| shfmt-version | The version of [shfmt](https://github.com/mvdan/sh#shfmt) to use. |
+| terraform-version | The version of [Terraform](https://terraform.io) to use. |
+| terraform-docs-version | The version of [terraform-docs](https://github.com/terraform-docs/terraform-docs) to use. |
 
 ## Usage ##
 

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ branding:
   color: purple
 description: Setup a shared GitHub Actions workflow environment.
 outputs:
-  PACKER_VERSION:
+  packer-version:
     description: The version of Packer to use.
-  SHFMT_VERSION:
+  shfmt-version:
     description: The version of shfmt to use.
-  TERRAFORM_VERSION:
+  terraform-version:
     description: The version of Terraform to use.
-  TERRAFORM_DOCS_VERSION:
+  terraform-docs-version:
     description: The version of terraform-docs to use.
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,3 +11,8 @@ terraform_docs_version=v0.14.1
   echo "TERRAFORM_VERSION=$terraform_version"
   echo "TERRAFORM_DOCS_VERSION=$terraform_docs_version"
 } >> "$GITHUB_ENV"
+
+echo "::set-output name=packer-version::$packer_version"
+echo "::set-output name=shfmt-version::$shfmt_version"
+echo "::set-output name=terraform-version::$terraform_version"
+echo "::set-output name=terraform-docs-version::$terraform_docs_version"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
+packer_version=1.7.3
+shfmt_version=v3.3.0
+terraform_version=0.14.11
+terraform_docs_version=v0.14.1
+
 {
-  echo "PACKER_VERSION=1.7.3"
-  echo "SHFMT_VERSION=v3.3.0"
-  echo "TERRAFORM_VERSION=0.14.11"
-  echo "TERRAFORM_DOCS_VERSION=v0.14.1"
+  echo "PACKER_VERSION=$packer_version"
+  echo "SHFMT_VERSION=$shfmt_version"
+  echo "TERRAFORM_VERSION=$terraform_version"
+  echo "TERRAFORM_DOCS_VERSION=$terraform_docs_version"
 } >> "$GITHUB_ENV"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the configuration of this Action to correctly output the program versions as the README describes.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This Action has claimed to set outputs but has instead only polluted the global environment space in workflows that use it to for consistent program version usage. This PR will allow workflows that use this action to reference program versions using the `steps.<id of step using this Action>.outputs.<program-version>` form. This will allow us to transition away from environment values in dependent workflows and we can remove setting those environment values in this Action at a future date.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass. I used [cisagov/skeleton-generic@testing/test_setup-env-github-action_changes](https://github.com/cisagov/skeleton-generic/tree/testing/test_setup-env-github-action_changes) to validate functionality.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
