### PR TITLE
Include GoMock and go-junit-report versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ None
 
 | Name              | Description |
 |-------------------|-------------|
+| go-junit-report-version | The version of [go-junit-report](https://github.com/jstemmer/go-junit-report) to use. |
+| go-mock-version | The version of [go-mock](https://github.com/golang/mock) to use. |
 | packer-version | The version of [Packer](https://packer.io) to use. |
 | shfmt-version | The version of [shfmt](https://github.com/mvdan/sh#shfmt) to use. |
 | terraform-version | The version of [Terraform](https://terraform.io) to use. |
 | terraform-docs-version | The version of [terraform-docs](https://github.com/terraform-docs/terraform-docs) to use. |
+
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ None
 | terraform-version | The version of [Terraform](https://terraform.io) to use. |
 | terraform-docs-version | The version of [terraform-docs](https://github.com/terraform-docs/terraform-docs) to use. |
 
-
 ## Usage ##
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ None
 | Name              | Description |
 |-------------------|-------------|
 | go-junit-report-version | The version of [go-junit-report](https://github.com/jstemmer/go-junit-report) to use. |
-| go-mock-version | The version of [go-mock](https://github.com/golang/mock) to use. |
+| gomock-version | The version of [GoMock](https://github.com/golang/mock) to use. |
 | packer-version | The version of [Packer](https://packer.io) to use. |
 | shfmt-version | The version of [shfmt](https://github.com/mvdan/sh#shfmt) to use. |
 | terraform-version | The version of [Terraform](https://terraform.io) to use. |

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ outputs:
   terraform-docs-version:
     description: The version of terraform-docs to use.
     value: ${{ steps.terraform-docs.outputs.version }}
+  go-mock-version:
+    description: The version of go mock to use.
+    value: ${{ steps.go-mock-version.outputs.version }}
+  go-junit-report-version:
+    description: The version of go junit report to use.
+    value: ${{ steps.go-junit-report.outputs.version }}
 runs:
   using: "composite"
   steps:
@@ -32,4 +38,10 @@ runs:
       shell: bash
     - id: terraform-docs
       run: echo "version=v0.16.0" >> $GITHUB_OUTPUT
+      shell: bash
+    - id: go-mock-version
+      run: echo "version=1.6.0>> $GITHUB_OUTPUT
+      shell: bash
+    - id: go-junit-report-version
+      run: echo "version=2.0.0" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
       run: echo "version=2.0.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: go-mock
-      run: echo "version=1.6.0>> $GITHUB_OUTPUT
+      run: echo "version=1.6.0 >> $GITHUB_OUTPUT
       shell: bash
     - id: packer
       run: echo "version=1.8.2" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ runs:
   using: "composite"
   steps:
     - id: go-junit-report
-      run: echo "version=2.0.0" >> $GITHUB_OUTPUT
+      run: echo "version=v2.0.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: gomock
-      run: echo "version=1.6.0" >> $GITHUB_OUTPUT
+      run: echo "version=v1.6.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: packer
       run: echo "version=1.8.2" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,9 @@ outputs:
   go-junit-report-version:
     description: The version of jstemmer/go-junit-report to use.
     value: ${{ steps.go-junit-report.outputs.version }}
-  go-mock-version:
+  gomock-version:
     description: The version of golang/mock to use.
-    value: ${{ steps.go-mock.outputs.version }}
+    value: ${{ steps.gomock.outputs.version }}
   packer-version:
     description: The version of Packer to use.
     value: ${{ steps.packer.outputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - id: go-junit-report
       run: echo "version=2.0.0" >> $GITHUB_OUTPUT
       shell: bash
-    - id: go-mock
+    - id: gomock
       run: echo "version=1.6.0 >> $GITHUB_OUTPUT
       shell: bash
     - id: packer

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,12 @@ branding:
   color: purple
 description: Setup a shared GitHub Actions workflow environment.
 outputs:
+  go-junit-report-version:
+    description: The version of go junit report to use.
+    value: ${{ steps.go-junit-report.outputs.version }}
+  go-mock-version:
+    description: The version of go mock to use.
+    value: ${{ steps.go-mock.outputs.version }}
   packer-version:
     description: The version of Packer to use.
     value: ${{ steps.packer.outputs.version }}
@@ -18,15 +24,16 @@ outputs:
   terraform-docs-version:
     description: The version of terraform-docs to use.
     value: ${{ steps.terraform-docs.outputs.version }}
-  go-mock-version:
-    description: The version of go mock to use.
-    value: ${{ steps.go-mock-version.outputs.version }}
-  go-junit-report-version:
-    description: The version of go junit report to use.
-    value: ${{ steps.go-junit-report.outputs.version }}
+
 runs:
   using: "composite"
   steps:
+    - id: go-junit-report
+      run: echo "version=2.0.0" >> $GITHUB_OUTPUT
+      shell: bash
+    - id: go-mock
+      run: echo "version=1.6.0>> $GITHUB_OUTPUT
+      shell: bash
     - id: packer
       run: echo "version=1.8.2" >> $GITHUB_OUTPUT
       shell: bash
@@ -38,10 +45,4 @@ runs:
       shell: bash
     - id: terraform-docs
       run: echo "version=v0.16.0" >> $GITHUB_OUTPUT
-      shell: bash
-    - id: go-mock-version
-      run: echo "version=1.6.0>> $GITHUB_OUTPUT
-      shell: bash
-    - id: go-junit-report-version
-      run: echo "version=2.0.0" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
       run: echo "version=2.0.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: gomock
-      run: echo "version=1.6.0 >> $GITHUB_OUTPUT
+      run: echo "version=1.6.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: packer
       run: echo "version=1.8.2" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ branding:
 description: Setup a shared GitHub Actions workflow environment.
 outputs:
   go-junit-report-version:
-    description: The version of go junit report to use.
+    description: The version of jstemmer/go-junit-report to use.
     value: ${{ steps.go-junit-report.outputs.version }}
   go-mock-version:
-    description: The version of go mock to use.
+    description: The version of golang/mock to use.
     value: ${{ steps.go-mock.outputs.version }}
   packer-version:
     description: The version of Packer to use.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->


This PR is to track the versions for [GoMock](https://github.com/golang/mock) and [go-junit-report](https://github.com/jstemmer/go-junit-report) into this repo so it can be consumed/used in GitHub Actions workflows. 


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This change is based on the discussion https://github.com/cisagov/skeleton-golang-package/pull/2#discussion_r1177074251

This will allow us to track and store version numbers for these dependencies in one location as we've been doing.


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


Pre-commit verified syntactical accuracy. 

**Edit:**
I (@mcdonnnj) created a [test branch in  `cisagov/skeleton-golang-package`](https://github.com/cisagov/skeleton-golang-package/tree/testing/setup-env) to verify the functionality of this action. I verified that the two project versions added here were usable to install the projects in GitHub Actions.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.


