### PR TITLE
Add Rust to env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
           # it relies on the existence of a go.sum file.
           cache: false
           go-version: "1.20"
+      - id: setup-rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Lookup Go cache directory
         id: go-cache
         run: |


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->


This PR adds Rust to our env so it can be consumed/used in GitHub Actions workflows.  Specifically, [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This change is based on current team practices. 


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


Pre-commit verified syntactical accuracy. 

<!--**Edit:**
I (@mcdonnnj) created a [test branch in  `cisagov/skeleton-golang-package`](https://github.com/cisagov/skeleton-golang-package/tree/testing/setup-env) to verify the functionality of this action. I verified that the two project versions added here were usable to install the projects in GitHub Actions.-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
