### PR TITLE
Track the Python and Go versions we use for general GitHub Actions jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ None
 
 | Name              | Description |
 |-------------------|-------------|
+| go-version | The version (major.minor) of [Go](https://github.com/golang/go) to use. |
 | go-critic-version | The version of [go-critic](https://github.com/go-critic/go-critic) to use. |
 | go-junit-report-version | The version of [go-junit-report](https://github.com/jstemmer/go-junit-report) to use. |
 | gomock-version | The version of [GoMock](https://github.com/golang/mock) to use. |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ None
 | gomock-version | The version of [GoMock](https://github.com/golang/mock) to use. |
 | gosec-version | The version of [gosec](https://github.com/securego/gosec) to use. |
 | packer-version | The version of [Packer](https://packer.io) to use. |
+| python-version | The version (major.minor) of [Python](https://github.com/python/cpython) to use. |
 | shfmt-version | The version of [shfmt](https://github.com/mvdan/sh#shfmt) to use. |
 | staticcheck-version | The version of [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) to use. |
 | terraform-version | The version of [Terraform](https://terraform.io) to use. |

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ outputs:
   packer-version:
     description: The version of Packer to use.
     value: ${{ steps.packer.outputs.version }}
+  python-version:
+    description: The version (major.minor) of Python to use.
+    value: ${{ steps.python.outputs.version }}
   shfmt-version:
     description: The version of shfmt to use.
     value: ${{ steps.shfmt.outputs.version }}
@@ -57,6 +60,9 @@ runs:
       shell: bash
     - id: packer
       run: echo "version=1.9.2" >> $GITHUB_OUTPUT
+      shell: bash
+    - id: python
+      run: echo "version=3.12" >> $GITHUB_OUTPUT
       shell: bash
     - id: shfmt
       run: echo "version=v3.7.0" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ branding:
   color: purple
 description: Setup a shared GitHub Actions workflow environment.
 outputs:
+  go-version:
+    description: The version (major.minor) of Go to use.
+    value: ${{ steps.go.outputs.version }}
   go-critic-version:
     description: The version of go-critic to use.
     value: ${{ steps.go-critic.outputs.version }}
@@ -37,6 +40,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - id: go
+      run: echo "version=1.21" >> $GITHUB_OUTPUT
+      shell: bash
     - id: go-critic
       run: echo "version=v0.8.1" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This adds appropriate outputs to track the versions of Python and Go that should serve as "defaults" for use in our GitHub Actions workflows.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

It's somewhat cumbersome to keep updating all the different versions hard-coded in workflows. It would make sense to reference the outputs of this Action unless specifically undesired.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This change is used in https://github.com/cisagov/skeleton-generic/pull/157 to switch over to this change for our skeleton projects.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
