### PR TITLE
Update versions of Go related tools tracked in this repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           egress-policy: audit
       - id: setup-env
-        uses: cisagov/setup-env-github-action@develop
+        uses: cisagov/setup-env-github-action@improvement/update_versions
       - uses: actions/checkout@v4
       - id: setup-python
         uses: actions/setup-python@v5

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
       run: echo "version=1.22" >> $GITHUB_OUTPUT
       shell: bash
     - id: go-critic
-      run: echo "version=v0.8.1" >> $GITHUB_OUTPUT
+      run: echo "version=v0.11.3" >> $GITHUB_OUTPUT
       shell: bash
     - id: go-junit-report
       run: echo "version=v2.0.0" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
       run: echo "version=v1.6.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: gosec
-      run: echo "version=v2.16.0" >> $GITHUB_OUTPUT
+      run: echo "version=v2.19.0" >> $GITHUB_OUTPUT
       shell: bash
     # We are choosing to remain on v1.9 due to HashiCorp's decision to change
     # the license of Packer from MPL 2.0 to BSL starting with 1.10.0. This is

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
       run: echo "version=v2.1.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: goimports
-      run: echo "version=v0.17.0" >> $GITHUB_OUTPUT
+      run: echo "version=v0.20.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: gomock
       run: echo "version=v1.6.0" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
       run: echo "version=v3.8.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: staticcheck
-      run: echo "version=v0.4.3" >> $GITHUB_OUTPUT
+      run: echo "version=v0.4.7" >> $GITHUB_OUTPUT
       shell: bash
     # We are choosing to remain on v1.5 due to HashiCorp's decision to change
     # the license of Terraform from MPL 2.0 to BSL starting with 1.6.0. This is

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       run: echo "version=3.12" >> $GITHUB_OUTPUT
       shell: bash
     - id: shfmt
-      run: echo "version=v3.7.0" >> $GITHUB_OUTPUT
+      run: echo "version=v3.8.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: staticcheck
       run: echo "version=v0.4.3" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
   steps:
     - id: go
-      run: echo "version=1.21" >> $GITHUB_OUTPUT
+      run: echo "version=1.22" >> $GITHUB_OUTPUT
       shell: bash
     - id: go-critic
       run: echo "version=v0.8.1" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       run: echo "version=v0.11.3" >> $GITHUB_OUTPUT
       shell: bash
     - id: go-junit-report
-      run: echo "version=v2.0.0" >> $GITHUB_OUTPUT
+      run: echo "version=v2.1.0" >> $GITHUB_OUTPUT
       shell: bash
     - id: goimports
       run: echo "version=v0.17.0" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request bumps the following versions:
- Go from [1.21](https://go.dev/doc/go1.21) to [1.22](https://go.dev/doc/go1.22)
- go-critic from [v0.8.1](https://github.com/go-critic/go-critic/releases/tag/v0.8.1) to [v0.11.](https://github.com/go-critic/go-critic/releases/tag/v0.11.3)
  - [version diff](https://github.com/go-critic/go-critic/compare/v0.8.1...v0.11.3)
- go-junit-report from [v2.0.0](https://github.com/jstemmer/go-junit-report/releases/tag/v2.0.0) to [v2.1.0](https://github.com/jstemmer/go-junit-report/releases/tag/v2.1.0)
  - [version diff](https://github.com/jstemmer/go-junit-report/compare/v2.0.0...v2.1.0)
- goimports from [v0.17.0](https://github.com/golang/tools/releases/tag/v0.17.0) to [v0.20.0](https://github.com/golang/tools/releases/tag/v0.20.0)
  - [version diff](https://github.com/golang/tools/compare/v0.17.0...v0.20.0) (this is gnarly because it contains a lot of unrelated changes due to the repository housing multiple tools)
- gosec from [v2.16.0](https://github.com/securego/gosec/releases/tag/v2.16.0) to [v2.19.0](https://github.com/securego/gosec/releases/tag/v2.19.0)
  - [version diff](https://github.com/securego/gosec/compare/v2.16.0...v2.19.0)
- shfmt from [v3.7.0](https://github.com/mvdan/sh/releases/tag/v3.7.0) to [v3.8.0](https://github.com/mvdan/sh/releases/tag/v3.8.0)
  - [version diff](https://github.com/mvdan/sh/compare/v3.7.0...v3.8.0)
- staticcheck from [v0.4.3](https://github.com/dominikh/go-tools/releases/tag/2023.1.3) to [v0.4.7](https://github.com/dominikh/go-tools/releases/tag/2023.1.7)
  - [version diff](https://github.com/dominikh/go-tools/compare/v0.4.3...v0.4.7)
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We need Go 1.22 to build the [testing branch of `terraform-docs`](https://github.com/mcdonnnj/terraform-docs/tree/improvement/support_atx_closed_markdown_headers) after I rebased to update it against the upstream `master`. While updating that I figured it would be good to update other versions managed here as appropriate.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. Since this is a lot of Go changes I also [tested in cisagov/skeleton-golang-package](https://github.com/cisagov/skeleton-golang-package/actions/runs/8885262665).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.