### PR TITLE
Exclude `package-lock.json` from `pretty-format-json` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
       - id: pretty-format-json
         args:
           - --autofix
+        exclude: package-lock.json
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         exclude: ^dist/


### PR DESCRIPTION
## 🗣 Description ##

This pull request `exclude`s `package-lock.json` from `pretty-format-json` `pre-commit` hook.

## 💭 Motivation and context ##

We can just let `npm` format this file however it wants to and avoid having to reformat it when Dependabot makes a pull request to update a dependency.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.