### PR TITLE
Adjust the bump-version script to use npm functionality

### DIFF
--- a/bump-version
+++ b/bump-version
@@ -10,7 +10,7 @@ set -o pipefail
 # Stores the canonical version for the project.
 VERSION_FILE=package.json
 # Files that should be updated with the new version.
-VERSION_FILES=("$VERSION_FILE")
+VERSION_FILES=("$VERSION_FILE" package-lock.json)
 
 USAGE=$(
   cat << END_OF_LINE
@@ -32,7 +32,9 @@ END_OF_LINE
 old_version=$(sed -n "s/^[[:blank:]]*\"version\": \"\(.*\)\",\{0,1\}$/\1/p" $VERSION_FILE)
 # Comment out periods so they are interpreted as periods and don't
 # just match any character
-old_version_regex="^\([[:blank:]]*\"version\": \)\"${old_version//\./\\\.}\""
+# We are not currently using this, but it will be necessary if we need to work with
+# non-npm files in the future.
+# old_version_regex="^\([[:blank:]]*\"version\": \)\"${old_version//\./\\\.}\""
 new_version="$old_version"
 
 bump_part=""
@@ -154,15 +156,21 @@ if [ "$with_prerelease" = true ]; then
   new_version="$temp_version"
 fi
 
-tmp_file=/tmp/version.$$
-for version_file in "${VERSION_FILES[@]}"; do
-  if [ ! -f "$version_file" ]; then
-    echo Missing expected file: "$version_file"
-    exit 1
-  fi
-  sed "s/$old_version_regex/\1\"$new_version\"/" "$version_file" > $tmp_file
-  mv $tmp_file "$version_file"
-done
+# We are not currently using this, but it will be necessary if we need to work with
+# non-npm files in the future.
+# tmp_file=/tmp/version.$$
+# for version_file in "${VERSION_FILES[@]}"; do
+#   if [ ! -f "$version_file" ]; then
+#     echo Missing expected file: "$version_file"
+#     exit 1
+#   fi
+#   sed "s/$old_version_regex/\1\"$new_version\"/" "$version_file" > $tmp_file
+#   mv $tmp_file "$version_file"
+# done
+
+# Use npm's built-in functionality to update the version of the package. We use the
+# `--no-git-tag-version` option to prevent npm from committing and creating a tag.
+npm version --no-git-tag-version "$new_version"
 
 git add "${VERSION_FILES[@]}"
 git commit --message "$commit_prefix version from $old_version to $new_version"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjusts the `bump-version` script to use `npm` to change the version in package files.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I noticed that the `bump-version` script at present does not update the version of the package in the `package-lock.json` file. While I initially considered just adding that file to the list, I thought it might be beneficial to use `npm`'s built-in functionality to change a package's version. This will ensure that any package files that need to reflect the new version are updated accordingly.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I did some test version bumps and everything looked as one would expect.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
