### PR TITLE
Regenerate distribution files when bumping the version

### DIFF
--- a/bump-version
+++ b/bump-version
@@ -10,7 +10,7 @@ set -o pipefail
 # Stores the canonical version for the project.
 VERSION_FILE=package.json
 # Files that should be updated with the new version.
-VERSION_FILES=("$VERSION_FILE" package-lock.json)
+VERSION_FILES=("$VERSION_FILE" package-lock.json dist/index.js)
 
 USAGE=$(
   cat << END_OF_LINE
@@ -175,7 +175,7 @@ npm version --no-git-tag-version "$new_version"
 # Regenerate distribution files since they include the package version
 npm run package
 
-git add "${VERSION_FILES[@]}" dist/
+git add "${VERSION_FILES[@]}"
 git commit --message "$commit_prefix version from $old_version to $new_version"
 
 if [ "$with_push" = true ]; then

--- a/bump-version
+++ b/bump-version
@@ -172,7 +172,10 @@ fi
 # `--no-git-tag-version` option to prevent npm from committing and creating a tag.
 npm version --no-git-tag-version "$new_version"
 
-git add "${VERSION_FILES[@]}"
+# Regenerate distribution files since they include the package version
+npm run package
+
+git add "${VERSION_FILES[@]}" dist/
 git commit --message "$commit_prefix version from $old_version to $new_version"
 
 if [ "$with_push" = true ]; then


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `bump-version` script to regenerate distribution files when bumping the version.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The package information is included in distribution files so we should ensure the version there is kept up-to-date.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
